### PR TITLE
fix(booking): self-healing hold expiry + payment reconciliation fallback

### DIFF
--- a/src/app/api/availability/route.ts
+++ b/src/app/api/availability/route.ts
@@ -12,7 +12,9 @@ import {
   getDayOfWeek,
   generateTimeSlots,
   isSlotBlocked,
+  now,
 } from "@/lib/dates";
+import { isHoldExpired } from "@/server/booking/hold-expiry";
 
 export async function GET(request: Request) {
   // Apply rate limiting: 30 requests per minute
@@ -124,6 +126,8 @@ export async function GET(request: Request) {
       .select({
         time: appointments.time,
         durationMinutes: services.durationMinutes,
+        status: appointments.status,
+        createdAt: appointments.createdAt,
       })
       .from(appointments)
       .innerJoin(services, eq(appointments.serviceId, services.id))
@@ -135,9 +139,16 @@ export async function GET(request: Request) {
         ),
       );
 
+    // Abandoned checkout holds (pending past the TTL) no longer block the slot —
+    // MercadoPago sends no webhook on abandonment, so they'd otherwise linger.
+    const currentTime = now();
+    const blockingAppointments = existingAppointments.filter(
+      (apt) => !isHoldExpired(apt, currentTime),
+    );
+
     // Map slots to include availability
     const slotsWithAvailability = timeSlots.map((time) => {
-      const blocked = existingAppointments.some((apt) => {
+      const blocked = blockingAppointments.some((apt) => {
         if (!apt.time) {
           return false;
         }

--- a/src/app/api/mercadopago/webhooks/route.ts
+++ b/src/app/api/mercadopago/webhooks/route.ts
@@ -1,12 +1,8 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { MercadoPagoConfig, Payment } from "mercadopago";
-import { db } from "@/drizzle";
-import { payments, appointments, barbers, services } from "@/drizzle/schema";
-import { eq } from "drizzle-orm";
 import { env } from "@/env";
 import { verifyMercadoPagoSignature } from "@/server/payments/webhook-signature";
-import { sendAppointmentConfirmation } from "@/lib/email";
-import { formatTime, toArgentinaDate } from "@/lib/dates";
+import { applyMercadoPagoPayment } from "@/server/payments/apply-payment";
 import { logger } from "@/lib/logger";
 
 let client: MercadoPagoConfig | undefined;
@@ -51,7 +47,12 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    await handlePaymentNotification(dataId);
+    const payment = new Payment(getClient());
+    const paymentData = await payment.get({ id: dataId });
+    if (!paymentData) {
+      throw new Error(`Payment ${dataId} not found in MercadoPago`);
+    }
+    await applyMercadoPagoPayment(paymentData);
     return NextResponse.json({ received: true });
   } catch (error) {
     // Return 500 so MercadoPago retries the notification
@@ -59,175 +60,5 @@ export async function POST(request: NextRequest) {
       paymentId: dataId,
     });
     return NextResponse.json({ error: "Processing failed" }, { status: 500 });
-  }
-}
-
-async function handlePaymentNotification(paymentId: string) {
-  const payment = new Payment(getClient());
-  const paymentData = await payment.get({ id: paymentId });
-
-  if (!paymentData) {
-    throw new Error(`Payment ${paymentId} not found in MercadoPago`);
-  }
-
-  const externalReference = paymentData.external_reference;
-  if (!externalReference || !externalReference.startsWith("appointment-")) {
-    logger.warn("Webhook payment with unknown external reference", {
-      paymentId,
-      externalReference,
-    });
-    return;
-  }
-
-  const appointmentId = parseInt(externalReference.replace("appointment-", ""));
-
-  const [appointmentRow] = await db
-    .select({
-      id: appointments.id,
-      status: appointments.status,
-      appointmentAt: appointments.appointmentAt,
-      customerName: appointments.customerName,
-      customerEmail: appointments.customerEmail,
-      servicePriceCents: services.priceCents,
-      serviceName: services.name,
-      barberName: barbers.name,
-    })
-    .from(appointments)
-    .innerJoin(services, eq(appointments.serviceId, services.id))
-    .innerJoin(barbers, eq(appointments.barberId, barbers.id))
-    .where(eq(appointments.id, appointmentId))
-    .limit(1);
-
-  if (!appointmentRow) {
-    logger.warn("Webhook for unknown appointment", { paymentId, appointmentId });
-    return;
-  }
-
-  const paymentStatus = mapMercadoPagoStatus(paymentData.status);
-  const amountCents = Math.round((paymentData.transaction_amount || 0) * 100);
-
-  // Upsert the payment record
-  const [existingPayment] = await db
-    .select({ id: payments.id, status: payments.status })
-    .from(payments)
-    .where(eq(payments.mercadopagoPaymentId, paymentId))
-    .limit(1);
-
-  // Never let an out-of-order pending/processing notification downgrade a
-  // terminal payment status (succeeded/refunded)
-  const isDowngrade =
-    existingPayment &&
-    (existingPayment.status === "succeeded" ||
-      existingPayment.status === "refunded") &&
-    (paymentStatus === "pending" || paymentStatus === "processing");
-  const effectiveStatus = isDowngrade ? existingPayment.status : paymentStatus;
-
-  const paymentFields = {
-    status: effectiveStatus,
-    mercadopagoPaymentMethodId: paymentData.payment_method_id ?? null,
-    mercadopagoPaymentType: paymentData.payment_type_id ?? null,
-    mercadopagoInstallments: paymentData.installments ?? null,
-    mercadopagoCardLastFourDigits: paymentData.card?.last_four_digits ?? null,
-    mercadopagoPayerEmail: paymentData.payer?.email ?? null,
-    mercadopagoProcessingMode: paymentData.processing_mode ?? null,
-    mercadopagoOperationType: paymentData.operation_type ?? null,
-    mercadopagoTransactionDetails: paymentData.transaction_details ?? null,
-    mercadopagoStatusDetail: paymentData.status_detail ?? null,
-    mercadopagoFailureReason:
-      paymentData.status === "rejected"
-        ? paymentData.status_detail ?? null
-        : null,
-    updatedAt: new Date(),
-  };
-
-  if (existingPayment) {
-    await db
-      .update(payments)
-      .set(paymentFields)
-      .where(eq(payments.id, existingPayment.id));
-  } else {
-    await db.insert(payments).values({
-      appointmentId,
-      amountCents,
-      method: "mercadopago",
-      mercadopagoPaymentId: paymentId,
-      mercadopagoPreferenceId: paymentData.order?.id?.toString() ?? null,
-      mercadopagoExternalReference: externalReference,
-      ...paymentFields,
-    });
-  }
-
-  // TODO Phase 1: handle "refunded"/"charged_back" — currently only the payment
-  // record reflects the refund; the appointment stays confirmed and must be
-  // reconciled manually from the dashboard.
-  if (paymentStatus === "succeeded") {
-    // Verify the paid amount covers the service price before confirming
-    if (amountCents < appointmentRow.servicePriceCents) {
-      logger.error(
-        "Payment amount mismatch — not confirming appointment",
-        undefined,
-        {
-          paymentId,
-          appointmentId,
-          amountCents,
-          expected: appointmentRow.servicePriceCents,
-        },
-      );
-      return;
-    }
-
-    const wasAlreadyConfirmed = appointmentRow.status === "confirmed";
-
-    await db
-      .update(appointments)
-      .set({ status: "confirmed", updatedAt: new Date() })
-      .where(eq(appointments.id, appointmentId));
-
-    if (
-      !wasAlreadyConfirmed &&
-      appointmentRow.customerEmail &&
-      appointmentRow.appointmentAt
-    ) {
-      try {
-        await sendAppointmentConfirmation({
-          customerName: appointmentRow.customerName ?? "Cliente",
-          customerEmail: appointmentRow.customerEmail,
-          date: appointmentRow.appointmentAt,
-          time: formatTime(toArgentinaDate(appointmentRow.appointmentAt)),
-          service: appointmentRow.serviceName,
-          barberName: appointmentRow.barberName,
-        });
-      } catch (error) {
-        // Don't fail the webhook over email — payment is already recorded
-        logger.error("Failed to send confirmation email", error as Error, {
-          appointmentId,
-        });
-      }
-    }
-  } else if (paymentStatus === "failed" && appointmentRow.status === "pending") {
-    await db
-      .update(appointments)
-      .set({ status: "cancelled", updatedAt: new Date() })
-      .where(eq(appointments.id, appointmentId));
-  }
-}
-
-function mapMercadoPagoStatus(
-  status: string | undefined,
-): "pending" | "processing" | "succeeded" | "failed" | "refunded" {
-  switch (status) {
-    case "approved":
-      return "succeeded";
-    case "pending":
-    case "in_process":
-      return "processing";
-    case "rejected":
-    case "cancelled":
-      return "failed";
-    case "refunded":
-    case "charged_back":
-      return "refunded";
-    default:
-      return "pending";
   }
 }

--- a/src/app/book/success/booking-result.test.ts
+++ b/src/app/book/success/booking-result.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { bookingResultContent } from "./booking-result";
+
+describe("bookingResultContent", () => {
+  it("celebrates a confirmed booking", () => {
+    const content = bookingResultContent("confirmed");
+    expect(content.tone).toBe("success");
+    expect(content.title).toMatch(/confirm/i);
+  });
+
+  it("tells a pending booking we're still finalizing payment", () => {
+    const content = bookingResultContent("pending");
+    expect(content.tone).toBe("pending");
+    expect(content.description).toMatch(/email/i);
+  });
+
+  it("explains a cancelled booking instead of claiming success", () => {
+    const content = bookingResultContent("cancelled");
+    expect(content.tone).toBe("cancelled");
+    expect(content.title).not.toMatch(/thank you/i);
+  });
+
+  it("falls back to a neutral booked message for unexpected statuses", () => {
+    const content = bookingResultContent("completed");
+    expect(content.tone).toBe("success");
+  });
+});

--- a/src/app/book/success/booking-result.ts
+++ b/src/app/book/success/booking-result.ts
@@ -1,0 +1,37 @@
+export type BookingTone = "success" | "pending" | "cancelled";
+
+export interface BookingResultContent {
+  tone: BookingTone;
+  title: string;
+  description: string;
+}
+
+/**
+ * Map a booking's status to the message shown on the result page. Keeps the
+ * page honest: a still-`pending` payment is not announced as a confirmed
+ * booking, and a `cancelled` one explains the failed payment.
+ */
+export function bookingResultContent(status: string): BookingResultContent {
+  switch (status) {
+    case "pending":
+      return {
+        tone: "pending",
+        title: "Almost there!",
+        description:
+          "We're finalizing your payment. You'll get an email as soon as your appointment is confirmed.",
+      };
+    case "cancelled":
+      return {
+        tone: "cancelled",
+        title: "Booking not completed",
+        description:
+          "Your payment didn't go through, so this appointment wasn't reserved. You can try booking again.",
+      };
+    default:
+      return {
+        tone: "success",
+        title: "Your appointment is confirmed!",
+        description: "Thank you for choosing us — we look forward to seeing you.",
+      };
+  }
+}

--- a/src/app/book/success/page.tsx
+++ b/src/app/book/success/page.tsx
@@ -3,14 +3,16 @@
 import { useSearchParams } from "next/navigation";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { CalendarCheck, Mail, ArrowLeft, Loader2 } from "lucide-react";
+import { CalendarCheck, Clock, XCircle, Mail, ArrowLeft, Loader2 } from "lucide-react";
 import Link from "next/link";
 import { formatDate, formatTime, toArgentinaDate } from "@/lib/dates";
 import { Suspense, useEffect, useState } from "react";
 import { getPublicAppointmentByPublicId } from "@/server/actions/appointments";
+import { bookingResultContent } from "./booking-result";
 
 interface AppointmentDetails {
   id: string;
+  status: string;
   appointmentAt: Date | null;
   barberName: string;
   serviceName: string;
@@ -96,51 +98,81 @@ function BookingDetails() {
     ? formatTime(toArgentinaDate(new Date(appointment.appointmentAt)))
     : "";
 
+  const content = bookingResultContent(appointment.status);
+  const toneStyles = {
+    success: {
+      Icon: CalendarCheck,
+      iconClass: "text-primary",
+      bgClass: "bg-primary/10",
+    },
+    pending: {
+      Icon: Clock,
+      iconClass: "text-yellow-600",
+      bgClass: "bg-yellow-500/10",
+    },
+    cancelled: {
+      Icon: XCircle,
+      iconClass: "text-red-600",
+      bgClass: "bg-red-500/10",
+    },
+  } as const;
+  const { Icon, iconClass, bgClass } = toneStyles[content.tone];
+  const isCancelled = content.tone === "cancelled";
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-background p-4">
       <Card className="w-full max-w-lg space-y-6 p-8 text-center">
         <div className="space-y-2">
           <div className="flex justify-center">
-            <div className="flex size-12 items-center justify-center rounded-full bg-primary/10">
-              <CalendarCheck className="size-6 text-primary" />
+            <div
+              className={`flex size-12 items-center justify-center rounded-full ${bgClass}`}
+            >
+              <Icon className={`size-6 ${iconClass}`} />
             </div>
           </div>
-          <h1 className="text-2xl font-bold tracking-tight">
-            Thank You for Choosing Us!
-          </h1>
-          <p className="text-muted-foreground">
-            Your appointment has been successfully booked
-          </p>
+          <h1 className="text-2xl font-bold tracking-tight">{content.title}</h1>
+          <p className="text-muted-foreground">{content.description}</p>
         </div>
 
-        <div className="space-y-4 rounded-lg bg-muted/50 p-6">
-          <div className="space-y-2">
-            <p className="text-lg font-medium">{formattedDate}</p>
-            <p className="font-semibold text-primary">{formattedTime}</p>
+        {!isCancelled && (
+          <div className="space-y-4 rounded-lg bg-muted/50 p-6">
+            <div className="space-y-2">
+              <p className="text-lg font-medium">{formattedDate}</p>
+              <p className="font-semibold text-primary">{formattedTime}</p>
+            </div>
+            <div className="space-y-1">
+              <p>
+                with{" "}
+                <span className="font-medium">{appointment.barberName}</span>
+              </p>
+              <p className="text-sm text-muted-foreground">
+                Service: {appointment.serviceName}
+              </p>
+            </div>
           </div>
-          <div className="space-y-1">
-            <p>
-              with <span className="font-medium">{appointment.barberName}</span>
-            </p>
-            <p className="text-sm text-muted-foreground">
-              Service: {appointment.serviceName}
-            </p>
-          </div>
-        </div>
+        )}
 
         <div className="space-y-4">
-          <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
-            <Mail className="size-4" />
-            <p>Please check your email for confirmation details</p>
-          </div>
+          {!isCancelled && (
+            <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
+              <Mail className="size-4" />
+              <p>Please check your email for confirmation details</p>
+            </div>
+          )}
 
           <div className="space-y-2">
-            <Link href="/">
-              <Button className="w-full">
-                <ArrowLeft className="mr-2 size-4" />
-                Return to Home
-              </Button>
-            </Link>
+            {isCancelled ? (
+              <Link href="/book">
+                <Button className="w-full">Try Again</Button>
+              </Link>
+            ) : (
+              <Link href="/">
+                <Button className="w-full">
+                  <ArrowLeft className="mr-2 size-4" />
+                  Return to Home
+                </Button>
+              </Link>
+            )}
           </div>
         </div>
       </Card>

--- a/src/server/actions/appointments.ts
+++ b/src/server/actions/appointments.ts
@@ -13,6 +13,8 @@ import { z } from "zod";
 import { isOwner } from "@/lib/auth";
 import { revalidatePath } from "next/cache";
 import { getCurrentSalonId } from "@/lib/salon-context";
+import { reconcilePendingAppointment } from "@/server/payments/reconcile";
+import { logger } from "@/lib/logger";
 
 /**
  * Retrieves all appointments for current salon with related data
@@ -56,8 +58,13 @@ export async function getAppointments() {
 const publicIdSchema = z.string().uuid();
 
 /**
- * Get appointment details by public UUID (for the booking success page).
- * Uses the non-guessable publicId so appointment data can't be enumerated.
+ * Resolve a booking's details and current status by public UUID (for the
+ * booking result page). Uses the non-guessable publicId so appointment data
+ * can't be enumerated.
+ *
+ * If the booking is still `pending` (paid, but the payment webhook hasn't
+ * landed yet), this reconciles directly against MercadoPago first, so the
+ * customer sees an accurate status even when the webhook is delayed or lost.
  */
 export async function getPublicAppointmentByPublicId(publicId: string) {
   const parsed = publicIdSchema.safeParse(publicId);
@@ -69,6 +76,8 @@ export async function getPublicAppointmentByPublicId(publicId: string) {
     const [result] = await db
       .select({
         id: appointments.publicId,
+        numericId: appointments.id,
+        status: appointments.status,
         appointmentAt: appointments.appointmentAt,
         barberName: barbers.name,
         serviceName: services.name,
@@ -84,7 +93,27 @@ export async function getPublicAppointmentByPublicId(publicId: string) {
       return { success: false as const, error: "Appointment not found" };
     }
 
-    return { success: true as const, appointment: result };
+    let status = result.status;
+
+    // Webhook-loss fallback: verify the payment with MercadoPago and re-read.
+    if (status === "pending") {
+      try {
+        await reconcilePendingAppointment(result.numericId);
+        const [refreshed] = await db
+          .select({ status: appointments.status })
+          .from(appointments)
+          .where(eq(appointments.id, result.numericId))
+          .limit(1);
+        if (refreshed) status = refreshed.status;
+      } catch (error) {
+        logger.error("Payment reconciliation failed", error as Error, {
+          appointmentId: result.numericId,
+        });
+      }
+    }
+
+    const { numericId: _numericId, ...appointment } = result;
+    return { success: true as const, appointment: { ...appointment, status } };
   } catch {
     return { success: false as const, error: "Failed to fetch appointment" };
   }

--- a/src/server/actions/bookings.ts
+++ b/src/server/actions/bookings.ts
@@ -2,7 +2,7 @@
 
 import { db } from "@/drizzle";
 import { appointments, barbers, customers, services } from "@/drizzle/schema";
-import { and, eq, notInArray, sql } from "drizzle-orm";
+import { and, eq, lt, notInArray, sql } from "drizzle-orm";
 import { z } from "zod";
 import { revalidatePath } from "next/cache";
 import { headers } from "next/headers";
@@ -14,6 +14,7 @@ import {
   sanitizeTime,
 } from "@/lib/sanitize";
 import { parseDateTime, now, formatTime, toArgentinaDate } from "@/lib/dates";
+import { HOLD_TTL_MS } from "@/server/booking/hold-expiry";
 import { createPreferenceForAppointment } from "@/server/payments/mercadopago";
 import { sendAppointmentConfirmation } from "@/lib/email";
 import { logger } from "@/lib/logger";
@@ -132,6 +133,24 @@ export async function createBookingAction(
       const endDateTime = new Date(
         appointmentDateTime.getTime() + service.durationMinutes * 60000,
       );
+
+      // Release abandoned checkout holds that overlap this slot. A paid booking
+      // sits in `pending` and reserves its slot via the exclusion constraint,
+      // but MercadoPago sends no webhook when a customer abandons checkout. Past
+      // the hold TTL, cancel the stale hold so this booking — and the DB
+      // constraint — can claim the slot instead of being blocked forever.
+      const holdCutoff = new Date(now().getTime() - HOLD_TTL_MS);
+      await tx
+        .update(appointments)
+        .set({ status: "cancelled", updatedAt: new Date() })
+        .where(
+          and(
+            eq(appointments.barberId, barberId),
+            eq(appointments.status, "pending"),
+            lt(appointments.createdAt, holdCutoff),
+            sql`${appointments.appointmentAt} < ${endDateTime} AND ${appointments.endTime} > ${appointmentDateTime}`,
+          ),
+        );
 
       // Range-overlap check against any non-cancelled appointment.
       // The DB exclusion constraint is the real guarantee under concurrency;

--- a/src/server/booking/hold-expiry.test.ts
+++ b/src/server/booking/hold-expiry.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { isHoldExpired, HOLD_TTL_MS } from "./hold-expiry";
+
+const NOW = new Date("2026-06-19T12:00:00.000Z");
+const minutesAgo = (m: number) => new Date(NOW.getTime() - m * 60_000);
+
+describe("isHoldExpired", () => {
+  it("treats a pending hold older than the TTL as expired", () => {
+    expect(
+      isHoldExpired({ status: "pending", createdAt: minutesAgo(31) }, NOW),
+    ).toBe(true);
+  });
+
+  it("treats a fresh pending hold as still active", () => {
+    expect(
+      isHoldExpired({ status: "pending", createdAt: minutesAgo(5) }, NOW),
+    ).toBe(false);
+  });
+
+  it("expires exactly at the TTL boundary", () => {
+    const createdAt = new Date(NOW.getTime() - HOLD_TTL_MS);
+    expect(isHoldExpired({ status: "pending", createdAt }, NOW)).toBe(true);
+  });
+
+  it("never expires a confirmed appointment, however old", () => {
+    expect(
+      isHoldExpired({ status: "confirmed", createdAt: minutesAgo(999) }, NOW),
+    ).toBe(false);
+  });
+
+  it("never expires a cancelled appointment", () => {
+    expect(
+      isHoldExpired({ status: "cancelled", createdAt: minutesAgo(999) }, NOW),
+    ).toBe(false);
+  });
+});

--- a/src/server/booking/hold-expiry.ts
+++ b/src/server/booking/hold-expiry.ts
@@ -1,0 +1,23 @@
+/**
+ * A paid booking is inserted as `pending` and holds its slot via the
+ * no-double-booking exclusion constraint. If the customer abandons checkout,
+ * MercadoPago sends no webhook, so the hold would otherwise block the slot
+ * forever. After this TTL the hold is considered abandoned and the slot is
+ * reclaimable. Matches the MercadoPago preference expiry in
+ * `src/server/payments/mercadopago.ts` (30 minutes).
+ */
+export const HOLD_TTL_MS = 30 * 60 * 1000;
+
+/**
+ * True when an appointment is an abandoned payment hold whose TTL has elapsed.
+ * Only `pending` appointments can be holds — free bookings are `confirmed`
+ * immediately and paid bookings become `confirmed`/`cancelled` via the webhook.
+ */
+export function isHoldExpired(
+  appointment: { status: string; createdAt: Date },
+  now: Date,
+  ttlMs: number = HOLD_TTL_MS,
+): boolean {
+  if (appointment.status !== "pending") return false;
+  return now.getTime() - appointment.createdAt.getTime() >= ttlMs;
+}

--- a/src/server/payments/apply-payment.ts
+++ b/src/server/payments/apply-payment.ts
@@ -1,0 +1,189 @@
+import "server-only";
+import { db } from "@/drizzle";
+import { appointments, barbers, payments, services } from "@/drizzle/schema";
+import { eq } from "drizzle-orm";
+import { sendAppointmentConfirmation } from "@/lib/email";
+import { formatTime, toArgentinaDate } from "@/lib/dates";
+import { logger } from "@/lib/logger";
+import { decidePaymentOutcome, mapMercadoPagoStatus } from "./payment-status";
+
+/**
+ * The subset of a MercadoPago payment object we persist/act on. Modelled
+ * structurally (rather than importing the SDK's response type) so this stays
+ * decoupled from SDK internal type paths.
+ */
+export interface MercadoPagoPaymentData {
+  id?: string | number;
+  external_reference?: string | null;
+  status?: string;
+  transaction_amount?: number | null;
+  payment_method_id?: string | null;
+  payment_type_id?: string | null;
+  installments?: number | null;
+  card?: { last_four_digits?: string | null } | null;
+  payer?: { email?: string | null } | null;
+  processing_mode?: string | null;
+  operation_type?: string | null;
+  transaction_details?: unknown;
+  status_detail?: string | null;
+  order?: { id?: string | number | null } | null;
+}
+
+/**
+ * Persist a MercadoPago payment and reconcile the linked appointment's status.
+ * Idempotent and safe to call from both the webhook and the success-page
+ * reconciliation fallback — the payment record is upserted (with terminal-status
+ * downgrade protection) and the appointment is confirmed/cancelled per
+ * `decidePaymentOutcome`. The confirmation email is sent at most once.
+ */
+export async function applyMercadoPagoPayment(
+  paymentData: MercadoPagoPaymentData,
+): Promise<void> {
+  const externalReference = paymentData.external_reference;
+  if (!externalReference || !externalReference.startsWith("appointment-")) {
+    logger.warn("Payment with unknown external reference", {
+      paymentId: paymentData.id,
+      externalReference,
+    });
+    return;
+  }
+
+  const appointmentId = parseInt(externalReference.replace("appointment-", ""));
+  const paymentId = String(paymentData.id ?? "");
+
+  const [appointmentRow] = await db
+    .select({
+      id: appointments.id,
+      status: appointments.status,
+      appointmentAt: appointments.appointmentAt,
+      customerName: appointments.customerName,
+      customerEmail: appointments.customerEmail,
+      servicePriceCents: services.priceCents,
+      serviceName: services.name,
+      barberName: barbers.name,
+    })
+    .from(appointments)
+    .innerJoin(services, eq(appointments.serviceId, services.id))
+    .innerJoin(barbers, eq(appointments.barberId, barbers.id))
+    .where(eq(appointments.id, appointmentId))
+    .limit(1);
+
+  if (!appointmentRow) {
+    logger.warn("Payment for unknown appointment", { paymentId, appointmentId });
+    return;
+  }
+
+  const paymentStatus = mapMercadoPagoStatus(paymentData.status);
+  const amountCents = Math.round((paymentData.transaction_amount || 0) * 100);
+
+  // Upsert the payment record
+  const [existingPayment] = await db
+    .select({ id: payments.id, status: payments.status })
+    .from(payments)
+    .where(eq(payments.mercadopagoPaymentId, paymentId))
+    .limit(1);
+
+  // Never let an out-of-order pending/processing notification downgrade a
+  // terminal payment status (succeeded/refunded)
+  const isDowngrade =
+    existingPayment &&
+    (existingPayment.status === "succeeded" ||
+      existingPayment.status === "refunded") &&
+    (paymentStatus === "pending" || paymentStatus === "processing");
+  const effectiveStatus = isDowngrade ? existingPayment.status : paymentStatus;
+
+  const paymentFields = {
+    status: effectiveStatus,
+    mercadopagoPaymentMethodId: paymentData.payment_method_id ?? null,
+    mercadopagoPaymentType: paymentData.payment_type_id ?? null,
+    mercadopagoInstallments: paymentData.installments ?? null,
+    mercadopagoCardLastFourDigits: paymentData.card?.last_four_digits ?? null,
+    mercadopagoPayerEmail: paymentData.payer?.email ?? null,
+    mercadopagoProcessingMode: paymentData.processing_mode ?? null,
+    mercadopagoOperationType: paymentData.operation_type ?? null,
+    mercadopagoTransactionDetails: paymentData.transaction_details ?? null,
+    mercadopagoStatusDetail: paymentData.status_detail ?? null,
+    mercadopagoFailureReason:
+      paymentData.status === "rejected"
+        ? (paymentData.status_detail ?? null)
+        : null,
+    updatedAt: new Date(),
+  };
+
+  if (existingPayment) {
+    await db
+      .update(payments)
+      .set(paymentFields)
+      .where(eq(payments.id, existingPayment.id));
+  } else {
+    await db.insert(payments).values({
+      appointmentId,
+      amountCents,
+      method: "mercadopago",
+      mercadopagoPaymentId: paymentId,
+      mercadopagoPreferenceId: paymentData.order?.id?.toString() ?? null,
+      mercadopagoExternalReference: externalReference,
+      ...paymentFields,
+    });
+  }
+
+  // TODO Phase 1: handle "refunded"/"charged_back" — currently only the payment
+  // record reflects the refund; the appointment stays confirmed and must be
+  // reconciled manually from the dashboard.
+  const outcome = decidePaymentOutcome({
+    paymentStatus,
+    amountCents,
+    servicePriceCents: appointmentRow.servicePriceCents,
+    appointmentStatus: appointmentRow.status,
+  });
+
+  if (outcome === "amount_mismatch") {
+    logger.error(
+      "Payment amount mismatch — not confirming appointment",
+      undefined,
+      {
+        paymentId,
+        appointmentId,
+        amountCents,
+        expected: appointmentRow.servicePriceCents,
+      },
+    );
+    return;
+  }
+
+  if (outcome === "confirm") {
+    const wasAlreadyConfirmed = appointmentRow.status === "confirmed";
+
+    await db
+      .update(appointments)
+      .set({ status: "confirmed", updatedAt: new Date() })
+      .where(eq(appointments.id, appointmentId));
+
+    if (
+      !wasAlreadyConfirmed &&
+      appointmentRow.customerEmail &&
+      appointmentRow.appointmentAt
+    ) {
+      try {
+        await sendAppointmentConfirmation({
+          customerName: appointmentRow.customerName ?? "Cliente",
+          customerEmail: appointmentRow.customerEmail,
+          date: appointmentRow.appointmentAt,
+          time: formatTime(toArgentinaDate(appointmentRow.appointmentAt)),
+          service: appointmentRow.serviceName,
+          barberName: appointmentRow.barberName,
+        });
+      } catch (error) {
+        // Don't fail over email — the payment is already recorded
+        logger.error("Failed to send confirmation email", error as Error, {
+          appointmentId,
+        });
+      }
+    }
+  } else if (outcome === "cancel") {
+    await db
+      .update(appointments)
+      .set({ status: "cancelled", updatedAt: new Date() })
+      .where(eq(appointments.id, appointmentId));
+  }
+}

--- a/src/server/payments/payment-status.test.ts
+++ b/src/server/payments/payment-status.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { mapMercadoPagoStatus, decidePaymentOutcome } from "./payment-status";
+
+describe("mapMercadoPagoStatus", () => {
+  it("maps approved to succeeded", () => {
+    expect(mapMercadoPagoStatus("approved")).toBe("succeeded");
+  });
+
+  it("maps in-flight statuses to processing", () => {
+    expect(mapMercadoPagoStatus("pending")).toBe("processing");
+    expect(mapMercadoPagoStatus("in_process")).toBe("processing");
+  });
+
+  it("maps rejected and cancelled to failed", () => {
+    expect(mapMercadoPagoStatus("rejected")).toBe("failed");
+    expect(mapMercadoPagoStatus("cancelled")).toBe("failed");
+  });
+
+  it("maps refunds and chargebacks to refunded", () => {
+    expect(mapMercadoPagoStatus("refunded")).toBe("refunded");
+    expect(mapMercadoPagoStatus("charged_back")).toBe("refunded");
+  });
+
+  it("falls back to pending for unknown/undefined statuses", () => {
+    expect(mapMercadoPagoStatus(undefined)).toBe("pending");
+    expect(mapMercadoPagoStatus("something_new")).toBe("pending");
+  });
+});
+
+describe("decidePaymentOutcome", () => {
+  const base = {
+    paymentStatus: "succeeded" as const,
+    amountCents: 5000,
+    servicePriceCents: 5000,
+    appointmentStatus: "pending",
+  };
+
+  it("confirms when paid in full", () => {
+    expect(decidePaymentOutcome(base)).toBe("confirm");
+  });
+
+  it("confirms when the boundary amount exactly covers the price", () => {
+    expect(
+      decidePaymentOutcome({ ...base, amountCents: 5000, servicePriceCents: 5000 }),
+    ).toBe("confirm");
+  });
+
+  it("flags an underpayment instead of confirming", () => {
+    expect(decidePaymentOutcome({ ...base, amountCents: 4999 })).toBe(
+      "amount_mismatch",
+    );
+  });
+
+  it("cancels a pending appointment when payment fails", () => {
+    expect(
+      decidePaymentOutcome({
+        ...base,
+        paymentStatus: "failed",
+        appointmentStatus: "pending",
+      }),
+    ).toBe("cancel");
+  });
+
+  it("does not cancel an already-confirmed appointment on a failed notice", () => {
+    expect(
+      decidePaymentOutcome({
+        ...base,
+        paymentStatus: "failed",
+        appointmentStatus: "confirmed",
+      }),
+    ).toBe("noop");
+  });
+
+  it("does nothing for in-flight (processing) payments", () => {
+    expect(
+      decidePaymentOutcome({ ...base, paymentStatus: "processing" }),
+    ).toBe("noop");
+  });
+
+  it("does nothing for refunds (handled manually for now)", () => {
+    expect(
+      decidePaymentOutcome({ ...base, paymentStatus: "refunded" }),
+    ).toBe("noop");
+  });
+});

--- a/src/server/payments/payment-status.ts
+++ b/src/server/payments/payment-status.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure payment-decision logic shared by the MercadoPago webhook and the
+ * success-page reconciliation fallback. Kept free of DB/SDK I/O so both paths
+ * apply identical rules and the rules are unit-tested.
+ */
+
+export type PaymentStatus =
+  | "pending"
+  | "processing"
+  | "succeeded"
+  | "failed"
+  | "refunded";
+
+/** Normalize a raw MercadoPago payment status into our internal vocabulary. */
+export function mapMercadoPagoStatus(status: string | undefined): PaymentStatus {
+  switch (status) {
+    case "approved":
+      return "succeeded";
+    case "pending":
+    case "in_process":
+      return "processing";
+    case "rejected":
+    case "cancelled":
+      return "failed";
+    case "refunded":
+    case "charged_back":
+      return "refunded";
+    default:
+      return "pending";
+  }
+}
+
+export type PaymentOutcome = "confirm" | "cancel" | "amount_mismatch" | "noop";
+
+/**
+ * Decide what should happen to an appointment given a payment's status and
+ * amount. `confirm` only when fully paid; `amount_mismatch` guards against
+ * underpayment; `cancel` only releases a still-pending hold on failure.
+ */
+export function decidePaymentOutcome(params: {
+  paymentStatus: PaymentStatus;
+  amountCents: number;
+  servicePriceCents: number;
+  appointmentStatus: string;
+}): PaymentOutcome {
+  const { paymentStatus, amountCents, servicePriceCents, appointmentStatus } =
+    params;
+
+  if (paymentStatus === "succeeded") {
+    if (amountCents < servicePriceCents) return "amount_mismatch";
+    return "confirm";
+  }
+
+  if (paymentStatus === "failed" && appointmentStatus === "pending") {
+    return "cancel";
+  }
+
+  return "noop";
+}

--- a/src/server/payments/reconcile.ts
+++ b/src/server/payments/reconcile.ts
@@ -1,0 +1,37 @@
+import "server-only";
+import { MercadoPagoConfig, Payment } from "mercadopago";
+import { env } from "@/env";
+import { applyMercadoPagoPayment } from "./apply-payment";
+
+/**
+ * Fallback for when a payment webhook is delayed or lost: look up the
+ * appointment's payment(s) directly from MercadoPago and apply the result.
+ * Called when a customer lands back on the success page while their booking is
+ * still `pending`, so confirmation doesn't depend solely on webhook delivery.
+ */
+export async function reconcilePendingAppointment(
+  appointmentId: number,
+): Promise<void> {
+  const client = new MercadoPagoConfig({
+    accessToken: env.MERCADOPAGO_ACCESS_TOKEN,
+  });
+
+  const search = await new Payment(client).search({
+    options: { external_reference: `appointment-${appointmentId}` },
+  });
+
+  const results = search?.results ?? [];
+  if (results.length === 0) return;
+
+  // Prefer an approved payment; otherwise the most recently updated one.
+  const approved = results.find((payment) => payment.status === "approved");
+  const target =
+    approved ??
+    [...results].sort((a, b) =>
+      (b.date_last_updated ?? "").localeCompare(a.date_last_updated ?? ""),
+    )[0];
+
+  if (target) {
+    await applyMercadoPagoPayment(target);
+  }
+}


### PR DESCRIPTION
Fixes the three customer-facing failure paths found in the `/book` flow audit. Stacked on #3 (base `integration/sync-to-main`); will auto-retarget to `main` when #3 merges. TDD throughout — 21 new tests, 41 total. typecheck / lint / test / build all green.

## 🔴 Critical — abandoned checkouts no longer lock slots forever
A paid booking holds its slot as `pending` via the no-double-booking exclusion constraint, but MercadoPago sends **no webhook when a customer abandons checkout** — so the hold (and the slot) would linger forever, and the customer couldn't even rebook their own ghost-held slot.
- New pure `isHoldExpired()` (TTL matches the 30-min MP preference expiry) + tests.
- Availability API filters out expired holds, so the calendar shows them free.
- The booking transaction cancels overlapping expired holds before inserting, so the slot — and the DB constraint — accept the new booking. Self-healing, no cron needed.

## 🟠 High — paid-but-webhook-lost bookings self-correct
Confirmation previously depended entirely on webhook delivery. Now the success page reconciles a still-`pending` booking **directly against MercadoPago**.
- Extracted `applyMercadoPagoPayment()` — one code path shared by the webhook and the reconciler (single source of truth for confirm/cancel/email/payment-record).
- Pure `decidePaymentOutcome()` + `mapMercadoPagoStatus()` with tests (the latter was previously untested inline webhook logic).
- Webhook handler slimmed to fetch-and-delegate.

## 🟡 Medium — the success page tells the truth
It used to always render "successfully booked." Now `bookingResultContent()` (pure, tested) maps the real status → confirmed / pending ("finalizing payment, check your email") / cancelled ("payment didn't go through, try again").

## Already-solid paths (left as-is)
Double-submit (button disabled during transition + rate-limit + DB constraint) and amount-mismatch/refund handling were already correct — confirmed in the audit.
